### PR TITLE
fix: prepend dependency paths with "." rather than use relative paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,11 +19,11 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 
   <!-- Components -->
-  <script src="src/home.js" type="module"></script>
+  <script src="./src/home.js" type="module"></script>
 
   <!-- Styling -->
-  <link href="styles/banner.css" rel="stylesheet">
-  <link href="styles/footer.css" rel="stylesheet">
+  <link href="./styles/banner.css" rel="stylesheet">
+  <link href="./styles/footer.css" rel="stylesheet">
 </head>
 <body>
   <home-page></home-page>


### PR DESCRIPTION
Maybe the `.` at the beginning of the paths for js resources will help here?